### PR TITLE
make c_float typedef instead of #define

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -2,12 +2,13 @@
 #define DAQP_CONSTANTS_H
 
 #include <stddef.h>
+typedef double c_float;
 
 #define EMPTY_IND -1 
 #define NX work->n 
 #define N_CONSTR work->m 
 #define N_SIMPLE work->ms 
-#define c_float double 
+// #define c_float double 
 #define DAQP_INF ((c_float)1e30)
 
 // DEFAULT SETTINGS 


### PR DESCRIPTION
This was needed to compile acados with both DAQP and OSQP at the same time.