### PR TITLE
Avoid compiler to optimize away DAQPResult struct

### DIFF
--- a/interfaces/daqp-julia/Project.toml
+++ b/interfaces/daqp-julia/Project.toml
@@ -1,7 +1,7 @@
 name = "DAQPBase"
 uuid = "833476c3-a8c0-4073-9b64-6473509843fe"
 authors = ["Daniel Arnström <daniel.arnstrom@gmail.com>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 DAQP_jll = "5c51c916-43bf-57fe-9d62-13064ebbf40d"


### PR DESCRIPTION
Should fix #105. The compiler seems to sometimes not realize that a struct is modified with when calling the C function `daqp_solve`. Explicitly calling `unsafe_load` should fix this.