### PR TITLE
Scale internal tolerances with working precision (single-precision robustness)

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -11,6 +11,17 @@ extern "C" {
 #define DAQP_UNCONSTRAINED_OPTIMAL -2
 #define DAQP_INF ((c_float)1e30)
 
+// PRECISION-DEPENDENT TOLERANCES
+#ifdef DAQP_SINGLE_PRECISION
+#define DAQP_LU_SING_TOL   ((c_float)1e-6)  // pivot magnitude below this is singular (daqp_lu)
+#define DAQP_INIT_PRIM_TOL ((c_float)1e-5)  // slack "on bound" band for primal warm start
+#define DAQP_INIT_DUAL_TOL ((c_float)1e-6)  // multiplier sign threshold for dual warm start
+#else
+#define DAQP_LU_SING_TOL   ((c_float)1e-12)
+#define DAQP_INIT_PRIM_TOL ((c_float)1e-9)
+#define DAQP_INIT_DUAL_TOL ((c_float)1e-12)
+#endif
+
 // DEFAULT SETTINGS
 #define DAQP_DEFAULT_PRIM_TOL 1e-6
 #define DAQP_DEFAULT_DUAL_TOL 1e-12

--- a/src/api.c
+++ b/src/api.c
@@ -539,7 +539,7 @@ int daqp_first_violating(c_float* x, c_float* A, c_float* bu, c_float* bl, int n
 void daqp_primal_init_active(DAQPProblem* qp, c_float* x){
     int i,disp;
     c_float Ax, slack;
-    c_float tol= 1e-9;
+    c_float tol= DAQP_INIT_PRIM_TOL;
 
     // Simple constraints
     for(i=0; i < qp->ms; i++){
@@ -579,7 +579,7 @@ void daqp_primal_init_active(DAQPProblem* qp, c_float* x){
 // based on a dual iterate
 void daqp_dual_init_active(DAQPProblem* qp, c_float* lam){
     int i;
-    c_float tol = 1e-12;
+    c_float tol = DAQP_INIT_DUAL_TOL;
     for(i=0; i < qp->m; i++){
         if(qp->sense[i] & DAQP_IMMUTABLE) continue;
         if(lam[i] > tol){

--- a/src/utils.c
+++ b/src/utils.c
@@ -534,7 +534,7 @@ int daqp_lu(c_float* A, int* P, int n) {
         }
 
         // Check for singularity
-        if (max_val < 1e-12) return -1;
+        if (max_val < DAQP_LU_SING_TOL) return -1;
 
         // Swap rows in A
         for (int k = 0; k < n; k++) {


### PR DESCRIPTION
## Problem

Three internal tolerances are hard-coded as double literals that sit below the single-precision roundoff floor (`float` eps is about 1.2e-7). When DAQP is built with `-DDAQP_SINGLE_PRECISION` (a supported path; it is handled in the MATLAB interface) they misbehave:

- `src/utils.c`, the `daqp_lu` singularity check `max_val < 1e-12`. For a singular matrix the largest pivot is around float-noise magnitude (about 1e-7 for O(1) data), which is larger than `1e-12`. The check passes, so the factorization divides by that noise and pushes `Inf`/`NaN` into the AVI solve. In single precision, singular matrices are essentially never caught.
- `src/api.c`, `daqp_primal_init_active` (`tol = 1e-9`) and `daqp_dual_init_active` (`tol = 1e-12`). These "on-bound" and multiplier-sign bands are below the float floor, so the warm-start active-set heuristics degenerate: almost any nonzero slack or multiplier lands on the wrong side of the band.

## Change

Add precision-selected macros in `include/constants.h` and use them at the three sites:

| Macro | double | single |
|---|---|---|
| `DAQP_LU_SING_TOL` | 1e-12 | 1e-6 |
| `DAQP_INIT_PRIM_TOL` | 1e-9 | 1e-5 |
| `DAQP_INIT_DUAL_TOL` | 1e-12 | 1e-6 |

The double-precision values match the previous literals exactly, so default builds are unaffected. Only the `DAQP_SINGLE_PRECISION` path changes.

## Notes

- The single-precision values are picked to sit above the float roundoff floor; treat them as a starting point.
- The user-facing `DAQP_DEFAULT_*` settings are left alone to keep the scope small, though several of those are double-tuned too and could get the same treatment.

## Testing

Builds cleanly in both precisions:
```
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build
cmake -S . -B build_sp -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-DDAQP_SINGLE_PRECISION" && cmake --build build_sp
```
