### PR TITLE
Improve Eigen interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(daqp VERSION 0.8.6)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include(GNUInstallDirs)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -80,7 +81,6 @@ target_include_directories(daqp PUBLIC
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES}") # math for C api
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -Wextra")
 

--- a/interfaces/daqp-eigen/daqp.cpp
+++ b/interfaces/daqp-eigen/daqp.cpp
@@ -1,5 +1,6 @@
 #include "daqp.hpp"
 #include "utils.h"
+#include <utility>
 
 
 EigenDAQPResult::EigenDAQPResult()
@@ -15,25 +16,25 @@ EigenDAQPResult::EigenDAQPResult(int n, int m)
 }
 
 void EigenDAQPResult::resize_primal(int n) {
-    x_.conservativeResizeLike(Eigen::VectorXd::Zero(n));
+    x_.resize(n);
     x = x_.data();
 }
 
 void EigenDAQPResult::resize_dual(int m) {
-    lam_.conservativeResizeLike(Eigen::VectorXd::Zero(m));
+    lam_.resize(m);
     lam = lam_.data();
     slack_.resize(m);
 }
 
-Eigen::VectorXd EigenDAQPResult::get_primal() const {
+Eigen::VectorXd const& EigenDAQPResult::get_primal() const {
     return x_;
 }
 
-Eigen::VectorXd EigenDAQPResult::get_dual() const {
+Eigen::VectorXd const& EigenDAQPResult::get_dual() const {
     return lam_;
 }
 
-Eigen::VectorXd EigenDAQPResult::get_slack() const {
+Eigen::VectorXd const& EigenDAQPResult::get_slack() const {
     return slack_;
 }
 
@@ -52,6 +53,10 @@ Eigen::VectorXi EigenDAQPResult::get_active_set() const {
 
 void EigenDAQPResult::set_slack(Eigen::VectorXd const& slack) {
     slack_ = slack;
+}
+
+void EigenDAQPResult::set_slack(Eigen::VectorXd&& slack) {
+    slack_ = std::move(slack);
 }
 
 
@@ -77,25 +82,25 @@ Eigen::VectorXd compute_slacks(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dyna
 }
 
 
-EigenDAQPResult daqp_solve(Eigen::MatrixXd& H,
-                           Eigen::VectorXd& f,
-                           Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> A,
-                           Eigen::VectorXd& bu,
-                           Eigen::VectorXd& bl,
-                           Eigen::VectorXi& sense,
-                           Eigen::VectorXi& break_points) {
+EigenDAQPResult daqp_solve(Eigen::MatrixXd const& H,
+                           Eigen::VectorXd const& f,
+                           Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> const& A,
+                           Eigen::VectorXd const& bu,
+                           Eigen::VectorXd const& bl,
+                           Eigen::VectorXi const& sense,
+                           Eigen::VectorXi const& break_points) {
     int n       = A.cols();
     int m       = bu.size();
     int ms      = m - A.rows();
     int n_tasks = break_points.size();
 
-    double* H_ptr  = H.size() == 0 ? nullptr : H.data();
-    double* f_ptr  = f.size() == 0 ? nullptr : f.data();
-    double* A_ptr  = A.size() == 0 ? nullptr : A.data();
-    double* bu_ptr = bu.size() == 0 ? nullptr : bu.data();
-    double* bl_ptr = bl.size() == 0 ? nullptr : bl.data();
-    int* sense_ptr = sense.size() == 0 ? nullptr : sense.data();
-    int* bp_ptr    = break_points.size() == 0 ? nullptr : break_points.data();
+    double* H_ptr  = H.size() == 0 ? nullptr : const_cast<double*>(H.data());
+    double* f_ptr  = f.size() == 0 ? nullptr : const_cast<double*>(f.data());
+    double* A_ptr  = A.size() == 0 ? nullptr : const_cast<double*>(A.data());
+    double* bu_ptr = bu.size() == 0 ? nullptr : const_cast<double*>(bu.data());
+    double* bl_ptr = bl.size() == 0 ? nullptr : const_cast<double*>(bl.data());
+    int* sense_ptr = sense.size() == 0 ? nullptr : const_cast<int*>(sense.data());
+    int* bp_ptr    = break_points.size() == 0 ? nullptr : const_cast<int*>(break_points.data());
 
     assert(bu.size() == bl.size());
     assert(ms <= n);
@@ -112,20 +117,20 @@ EigenDAQPResult daqp_solve(Eigen::MatrixXd& H,
 
 // Solve: min_x 0.5 x'*H*x + f'*x
 //         s.t  bl<= A*x <= bu
-EigenDAQPResult daqp_solve(Eigen::MatrixXd& H,
-                           Eigen::VectorXd& f,
-                           Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> A,
-                           Eigen::VectorXd& bu,
-                           Eigen::VectorXd& bl) {
+EigenDAQPResult daqp_solve(Eigen::MatrixXd const& H,
+                           Eigen::VectorXd const& f,
+                           Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> const& A,
+                           Eigen::VectorXd const& bu,
+                           Eigen::VectorXd const& bl) {
     Eigen::VectorXi sense(0);
     Eigen::VectorXi break_points(0);
     return daqp_solve(H, f, A, bu, bl, sense, break_points);
 }
 
-EigenDAQPResult daqp_solve(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> A,
-                           Eigen::VectorXd& bu,
-                           Eigen::VectorXd& bl,
-                           Eigen::VectorXi& break_points) {
+EigenDAQPResult daqp_solve(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> const& A,
+                           Eigen::VectorXd const& bu,
+                           Eigen::VectorXd const& bl,
+                           Eigen::VectorXi const& break_points) {
     Eigen::MatrixXd H(0, 0);
     Eigen::VectorXd f(0);
     Eigen::VectorXi sense(0);
@@ -406,28 +411,28 @@ void DAQP::set_time_limit(double val) {
 }
 
 
-Eigen::VectorXd DAQP::get_primal() {
+Eigen::VectorXd const& DAQP::get_primal() {
     if (!is_solved_) {
         solve();
     }
     return result_.get_primal();
 }
 
-Eigen::VectorXd DAQP::get_dual() {
+Eigen::VectorXd const& DAQP::get_dual() {
     if (!is_solved_) {
         solve();
     }
     return result_.get_dual();
 }
 
-Eigen::VectorXd DAQP::get_slack() {
+Eigen::VectorXd const& DAQP::get_slack() {
     if (!is_solved_) {
         solve();
     }
 
     if (!is_slack_computed_) {
         Eigen::Map<const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> matrix(
-          qp_.A, qp_.m, qp_.n);
+          qp_.A, qp_.m - qp_.ms, qp_.n);
         Eigen::Map<const Eigen::VectorXd> upper(qp_.bupper, qp_.m);
         Eigen::Map<const Eigen::VectorXd> lower(qp_.blower, qp_.m);
 

--- a/interfaces/daqp-eigen/daqp.hpp
+++ b/interfaces/daqp-eigen/daqp.hpp
@@ -16,11 +16,12 @@ class EigenDAQPResult : public DAQPResult {
     EigenDAQPResult(int n, int m);
     void resize_primal(int n);
     void resize_dual(int m);
-    Eigen::VectorXd get_primal() const;
-    Eigen::VectorXd get_dual() const;
-    Eigen::VectorXd get_slack() const;
+    Eigen::VectorXd const& get_primal() const;
+    Eigen::VectorXd const& get_dual() const;
+    Eigen::VectorXd const& get_slack() const;
     Eigen::VectorXi get_active_set() const;
     void set_slack(Eigen::VectorXd const& slack);
+    void set_slack(Eigen::VectorXd&& slack);
 };
 
 
@@ -30,28 +31,28 @@ Eigen::VectorXd compute_slacks(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dyna
                                Eigen::VectorXd const& primal);
 
 
-EigenDAQPResult daqp_solve(Eigen::MatrixXd& H,
-                           Eigen::VectorXd& f,
-                           Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> A,
-                           Eigen::VectorXd& bu,
-                           Eigen::VectorXd& bl,
-                           Eigen::VectorXi& sense,
-                           Eigen::VectorXi& break_points);
+EigenDAQPResult daqp_solve(Eigen::MatrixXd const& H,
+                           Eigen::VectorXd const& f,
+                           Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> const& A,
+                           Eigen::VectorXd const& bu,
+                           Eigen::VectorXd const& bl,
+                           Eigen::VectorXi const& sense,
+                           Eigen::VectorXi const& break_points);
 
 // Solve: min_x 0.5 x'*H*x + f'*x
 //         s.t  bl<= A*x <= bu
-EigenDAQPResult daqp_solve(Eigen::MatrixXd& H,
-                           Eigen::VectorXd& f,
-                           Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> A,
-                           Eigen::VectorXd& bu,
-                           Eigen::VectorXd& bl);
+EigenDAQPResult daqp_solve(Eigen::MatrixXd const& H,
+                           Eigen::VectorXd const& f,
+                           Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> const& A,
+                           Eigen::VectorXd const& bu,
+                           Eigen::VectorXd const& bl);
 
 // Solve min_x ||x||
 //        s.t  bl <= A*x <= bu
-EigenDAQPResult daqp_solve(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> A,
-                           Eigen::VectorXd& bu,
-                           Eigen::VectorXd& bl,
-                           Eigen::VectorXi& break_points);
+EigenDAQPResult daqp_solve(Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> const& A,
+                           Eigen::VectorXd const& bu,
+                           Eigen::VectorXd const& bl,
+                           Eigen::VectorXi const& break_points);
 
 
 class DAQP {
@@ -108,9 +109,9 @@ class DAQP {
     void set_time_limit(double val);
 
     // Getters for result
-    Eigen::VectorXd get_primal();
-    Eigen::VectorXd get_dual();
-    Eigen::VectorXd get_slack();
+    Eigen::VectorXd const& get_primal();
+    Eigen::VectorXd const& get_dual();
+    Eigen::VectorXd const& get_slack();
     Eigen::VectorXi get_active_set();
     int get_status();
     int get_iterations();

--- a/interfaces/daqp-eigen/tests/04_slack_sign.cpp
+++ b/interfaces/daqp-eigen/tests/04_slack_sign.cpp
@@ -50,8 +50,17 @@ int main() {
     result     = solver.solve(A, bu, bl, break_points);
     bool test2 = verify_slack(result);
 
+    // Pure bounds are represented by a 0-by-n general constraint matrix.
+    // The class must map only those zero general rows when computing slacks.
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> no_general_constraints(0, 3);
+    Eigen::VectorXi no_hierarchy(0);
+    DAQP bounds_solver(3, 3, 0);
+    bounds_solver.solve(no_general_constraints, bu0, bl0, no_hierarchy);
+    bool test3 = bounds_solver.get_slack().isZero();
+
     std::cout << "Static function: " << (test1 ? "PASS" : "FAIL") << std::endl;
     std::cout << "Class method: " << (test2 ? "PASS" : "FAIL") << std::endl;
+    std::cout << "Pure-bound slacks: " << (test3 ? "PASS" : "FAIL") << std::endl;
 
-    return (test1 && test2) ? 0 : 1;
+    return (test1 && test2 && test3) ? 0 : 1;
 }


### PR DESCRIPTION
  - Eliminated copies when retrieving primal, dual, and slack vectors.
  - Removed unnecessary zero-initialization during result resizing.
  - Passed one-shot inputs by const reference, avoiding a row-major constraint-matrix copy.
  - Added move-based slack storage.
  - Fixed an out-of-bounds slack calculation for bound-only QPs and added a regression test.
  - Fixed PIC propagation when embedding the static DAQP library.